### PR TITLE
feat(codex): support Codex Responses web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Search the web using your currently selected model. Automatically picks the righ
 |---|---|
 | Google Gemini | Grounding with Google Search |
 | OpenAI | Responses API web search |
+| OpenAI Codex | Codex Responses API web search |
 | Anthropic | Messages API web search |
 
 Supports passing up to 20 additional URLs to analyze alongside the query.

--- a/src/api.ts
+++ b/src/api.ts
@@ -33,7 +33,7 @@ const GOOGLE_PROVIDERS: Record<string, ProviderConfig> = {
 
 export function getProviderKind(model: Model<any>): ProviderKind {
     if (GOOGLE_PROVIDERS[model.provider] || GOOGLE_PROVIDERS[model.api]) return "google";
-    if (model.api === "openai-responses") return "openai";
+    if (model.api === "openai-responses" || model.api === "openai-codex-responses") return "openai";
     if (model.api === "anthropic-messages") return "anthropic";
     return "unsupported";
 }
@@ -126,7 +126,7 @@ type SseEvent = {
 async function readSseEvents(
     response: Response,
     signal: AbortSignal | undefined,
-    onEvent: (event: SseEvent) => void | Promise<void>
+    onEvent: (event: SseEvent) => boolean | void | Promise<boolean | void>
 ): Promise<void> {
     if (!response.body) {
         throw new Error("No response body");
@@ -137,59 +137,78 @@ async function readSseEvents(
     let buffer = "";
     let currentEventData = "";
     let currentEventName = "";
+    let stopRequested = false;
+    let reachedEof = false;
 
-    const flushEvent = async () => {
-        if (!currentEventData) return;
+    const flushEvent = async (): Promise<boolean> => {
+        if (!currentEventData) return false;
         const raw = currentEventData.trim();
         currentEventData = "";
         const eventName = currentEventName;
         currentEventName = "";
-        if (!raw || raw === "[DONE]") return;
+        if (!raw || raw === "[DONE]") return false;
 
         let data: any;
         try {
             data = JSON.parse(raw);
         } catch {
-            return;
+            return false;
         }
-        await onEvent({ event: eventName, data });
+        return await onEvent({ event: eventName, data }) === true;
     };
 
-    while (true) {
-        if (signal?.aborted) {
-            throw new Error("Request was aborted");
-        }
-
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-            if (line === "" || line === "\r") {
-                await flushEvent();
-                continue;
+    try {
+        readLoop: while (true) {
+            if (signal?.aborted) {
+                throw new Error("Request was aborted");
             }
 
+            const { done, value } = await reader.read();
+            if (done) {
+                reachedEof = true;
+                break;
+            }
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() || "";
+
+            for (const line of lines) {
+                if (line === "" || line === "\r") {
+                    if (await flushEvent()) {
+                        stopRequested = true;
+                        break readLoop;
+                    }
+                    continue;
+                }
+
+                if (line.startsWith("data:")) {
+                    const data = line.slice(5).trim();
+                    currentEventData = currentEventData ? currentEventData + "\n" + data : data;
+                } else if (line.startsWith("event:")) {
+                    currentEventName = line.slice(6).trim();
+                }
+            }
+        }
+
+        if (!stopRequested && buffer.trim()) {
+            const line = buffer.trim();
             if (line.startsWith("data:")) {
                 const data = line.slice(5).trim();
                 currentEventData = currentEventData ? currentEventData + "\n" + data : data;
-            } else if (line.startsWith("event:")) {
-                currentEventName = line.slice(6).trim();
             }
         }
-    }
-
-    if (buffer.trim()) {
-        const line = buffer.trim();
-        if (line.startsWith("data:")) {
-            const data = line.slice(5).trim();
-            currentEventData = currentEventData ? currentEventData + "\n" + data : data;
+        if (!stopRequested) stopRequested = await flushEvent();
+    } finally {
+        if (!reachedEof) {
+            try {
+                await reader.cancel();
+            } catch {
+                // Ignore cancellation failures while cleaning up an interrupted stream.
+            }
         }
+        reader.releaseLock();
     }
-    await flushEvent();
 }
 
 function extractPromptFromGeminiBody(body: any): string {
@@ -208,6 +227,34 @@ function extractPromptFromGeminiBody(body: any): string {
 
 function trimTrailingSlash(value: string): string {
     return value.replace(/\/+$/, "");
+}
+
+function isOpenAICodexModel(model: Model<any>): boolean {
+    return model.api === "openai-codex-responses";
+}
+
+function resolveOpenAIResponsesUrl(model: Model<any>): string {
+    const base = trimTrailingSlash(model.baseUrl);
+    if (!isOpenAICodexModel(model)) return `${base}/responses`;
+    if (base.endsWith("/codex/responses")) return base;
+    if (base.endsWith("/codex")) return `${base}/responses`;
+    return `${base}/codex/responses`;
+}
+
+function extractOpenAICodexAccountId(token: string): string {
+    try {
+        const parts = token.split(".");
+        if (parts.length !== 3) throw new Error("Invalid token");
+        const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+        const bytes = Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
+        const payload = JSON.parse(new TextDecoder().decode(bytes));
+        const accountId = payload?.["https://api.openai.com/auth"]?.chatgpt_account_id;
+        if (typeof accountId !== "string" || !accountId) throw new Error("Missing account ID");
+        return accountId;
+    } catch {
+        throw new Error("Failed to extract ChatGPT account ID from openai-codex credentials");
+    }
 }
 
 function resolveAnthropicMessagesUrl(baseUrl: string): string {
@@ -561,31 +608,55 @@ async function callOpenAIStream(
         throw new Error(auth.error || "Failed to get API key and headers");
     }
 
-    const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-        "Accept": "text/event-stream",
-        ...(model.headers || {}),
-        ...(auth.headers || {}),
-    };
-    if (auth.apiKey && !headers.Authorization && !headers.authorization) {
-        headers.Authorization = `Bearer ${auth.apiKey}`;
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(model.headers || {})) headers.set(name, value);
+    for (const [name, value] of Object.entries(auth.headers || {})) headers.set(name, value);
+    if (!headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+    if (!headers.has("Accept")) headers.set("Accept", "text/event-stream");
+    if (auth.apiKey && !headers.has("Authorization")) headers.set("Authorization", `Bearer ${auth.apiKey}`);
+
+    const isCodex = isOpenAICodexModel(model);
+    if (isCodex) {
+        const authorization = headers.get("Authorization");
+        const hasBearerAuth = typeof authorization === "string" && /^Bearer\s+\S+/i.test(authorization);
+        if (!auth.apiKey && !hasBearerAuth) {
+            throw new Error("No OAuth credential configured for openai-codex model");
+        }
+        if (!headers.has("chatgpt-account-id")) {
+            if (!auth.apiKey) {
+                throw new Error("No ChatGPT account ID configured for openai-codex model");
+            }
+            headers.set("chatgpt-account-id", extractOpenAICodexAccountId(auth.apiKey));
+        }
+        if (!headers.has("originator")) headers.set("originator", "codex_cli_rs");
     }
+    const requestHeaders = Object.fromEntries(headers.entries());
 
     const requestBody: any = {
         model: model.id,
-        input: prompt,
+        input: isCodex
+            ? [{ role: "user", content: [{ type: "input_text", text: prompt }] }]
+            : prompt,
         tools: [{ type: "web_search" }],
-        include: ["web_search_call.action.sources", "web_search_call.results"],
+        include: isCodex
+            ? ["web_search_call.action.sources"]
+            : ["web_search_call.action.sources", "web_search_call.results"],
         stream: true,
         store: false,
     };
     if (model.reasoning) {
         requestBody.reasoning = { effort: "none" };
     }
+    if (isCodex) {
+        requestBody.instructions = "Answer the user's request using web search when needed.";
+        requestBody.text = { verbosity: "low" };
+        requestBody.tool_choice = "required";
+        requestBody.parallel_tool_calls = true;
+    }
 
-    const response = await fetch(`${trimTrailingSlash(model.baseUrl)}/responses`, {
+    const response = await fetch(resolveOpenAIResponsesUrl(model), {
         method: "POST",
-        headers,
+        headers: requestHeaders,
         body: JSON.stringify(requestBody),
         signal
     });
@@ -649,7 +720,14 @@ async function callOpenAIStream(
                 raw: action,
             });
         }
-        nativeSearchCalls.push(call);
+        const existingCall = call.id ? nativeSearchCalls.find((existing) => existing.id === call.id) : undefined;
+        if (existingCall) {
+            Object.assign(existingCall, Object.fromEntries(
+                Object.entries(call).filter(([, value]) => value !== undefined)
+            ));
+        } else {
+            nativeSearchCalls.push(call);
+        }
     };
 
     const collectFromResponse = (response: any) => {
@@ -664,7 +742,10 @@ async function callOpenAIStream(
     };
 
     await readSseEvents(response, signal, ({ data: event }) => {
-        if (event.type === "response.output_text.delta") {
+        if (event.type === "error" || event.type === "response.failed") {
+            const message = event.message || event.error?.message || event.response?.error?.message;
+            throw new Error(message || JSON.stringify(event.error || event.response?.error || event));
+        } else if (event.type === "response.output_text.delta") {
             accumulatedText += event.delta || "";
             onUpdate?.({
                 content: [{ type: "text", text: accumulatedText }],
@@ -674,8 +755,12 @@ async function callOpenAIStream(
             collectAnnotation(event.annotation);
         } else if (event.type === "response.output_item.added" || event.type === "response.output_item.done") {
             collectWebSearchCall(event.item);
-        } else if (event.type === "response.completed") {
+        } else if (event.type === "response.incomplete" || event.response?.status === "incomplete") {
             collectFromResponse(event.response);
+            if (isCodex) return true;
+        } else if (event.type === "response.completed" || event.type === "response.done") {
+            collectFromResponse(event.response);
+            if (isCodex) return true;
         } else if (event.type === "response.web_search_call.in_progress" || event.type === "response.web_search_call.searching" || event.type === "response.web_search_call.completed") {
             pushNativeSearchEvent(nativeSearchEvents, event.type);
             const call = nativeSearchCalls.find((item) => item.id === event.item_id);
@@ -687,11 +772,6 @@ async function callOpenAIStream(
                     details: { streaming: true, searching: true }
                 });
             }
-        } else if (event.type === "response.failed") {
-            const error = event.response?.error;
-            throw new Error(error?.message || JSON.stringify(error || event.response || event));
-        } else if (event.type === "error") {
-            throw new Error(event.message || JSON.stringify(event));
         }
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export function formatResult(text: string, details: any): AgentToolResult<any> {
 
 // --- Model Selection ---
 
-const SUPPORTED_PROVIDERS = ["google-generative-ai", "openai-responses", "anthropic-messages"];
+const SUPPORTED_PROVIDERS = ["google-generative-ai", "openai-responses", "openai-codex-responses", "anthropic-messages"];
 const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "agent", "web-search.json");
 
 type WebSearchModelConfig =

--- a/tests/api-parsing.test.mjs
+++ b/tests/api-parsing.test.mjs
@@ -9,6 +9,12 @@ import { getModel, getWebSearchModel, missingConfigResult, missingWebSearchConfi
 import { urlContext } from '../src/url_context.ts';
 import { webSearch } from '../src/web_search.ts';
 
+const OPENAI_CODEX_TOKEN = [
+  'eyJhbGciOiJub25lIn0',
+  'eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF90ZXN0In0sIm5vdGUiOiLguJrguLHguI3guIrguLU_MTAifQ',
+  'signature',
+].join('.');
+
 function sse(events) {
   return events.map((event) => {
     const name = event.event ? `event: ${event.event}\n` : '';
@@ -16,12 +22,13 @@ function sse(events) {
   }).join('');
 }
 
-function mockCtx(apiKey = 'test-key', model = undefined) {
+function mockCtx(apiKey, model = undefined, headers = undefined) {
+  const resolvedApiKey = arguments.length === 0 ? 'test-key' : apiKey;
   return {
     model,
     modelRegistry: {
       async getApiKeyAndHeaders() {
-        return { ok: true, apiKey };
+        return { ok: true, apiKey: resolvedApiKey, headers };
       },
       getAvailable() {
         return model ? [model] : [];
@@ -84,6 +91,359 @@ test('OpenAI stream exposes native search calls, queries, URLs, and citations', 
     assert.equal(result.sources[0].url, 'https://platform.openai.com/docs/guides/tools-web-search');
     assert.equal(result.sources[0].title, 'OpenAI docs');
     assert.equal(result.sources.length, 1);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream uses Codex Responses transport with native web search', async () => {
+  const previousFetch = globalThis.fetch;
+  const tokenPayload = OPENAI_CODEX_TOKEN.split('.')[1];
+  assert.match(tokenPayload, /[-_]/);
+  assert.notEqual(tokenPayload.length % 4, 0);
+  globalThis.fetch = async (url, init) => {
+    assert.equal(url, 'https://chatgpt.com/backend-api/codex/responses');
+    assert.equal(init.headers.authorization, `Bearer ${OPENAI_CODEX_TOKEN}`);
+    assert.equal(init.headers['chatgpt-account-id'], 'acct_test');
+    assert.equal(init.headers.originator, 'codex_cli_rs');
+    assert.equal(Object.keys(init.headers).some((key) => key.toLowerCase() === 'openai-beta'), false);
+
+    const body = JSON.parse(init.body);
+    assert.equal(body.model, 'gpt-5.5');
+    assert.deepEqual(body.input, [{
+      role: 'user',
+      content: [{ type: 'input_text', text: 'Search with Codex' }],
+    }]);
+    assert.deepEqual(body.tools, [{ type: 'web_search' }]);
+    assert.deepEqual(body.include, ['web_search_call.action.sources']);
+    assert.equal(body.tool_choice, 'required');
+    assert.equal(body.parallel_tool_calls, true);
+    assert.equal(body.stream, true);
+    assert.equal(body.store, false);
+
+    return makeResponse([
+      { data: { type: 'response.web_search_call.in_progress', item_id: 'ws_codex' } },
+      { data: { type: 'response.output_text.delta', delta: 'Codex search answer' } },
+      { data: { type: 'response.web_search_call.completed', item_id: 'ws_codex' } },
+      { data: { type: 'response.done', response: { output: [
+        { type: 'web_search_call', id: 'ws_codex', status: 'completed', action: { type: 'search', query: 'Codex web search' } },
+      ] } } },
+    ]);
+  };
+
+  try {
+    const result = await callApiStream(mockCtx(OPENAI_CODEX_TOKEN), {
+      id: 'gpt-5.5',
+      provider: 'openai-codex',
+      api: 'openai-codex-responses',
+      baseUrl: 'https://chatgpt.com/backend-api',
+      reasoning: true,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] });
+
+    assert.equal(result.providerKind, 'openai');
+    assert.equal(result.nativeSearchUsed, true);
+    assert.equal(result.text, 'Codex search answer');
+    assert.deepEqual(result.searchQueries, ['Codex web search']);
+    assert.equal(result.nativeSearchCalls.length, 1);
+    assert.equal(result.nativeSearchCalls[0].status, 'completed');
+    assert.deepEqual(result.nativeSearchCalls[0].queries, ['Codex web search']);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream stops after terminal event without waiting for EOF', async () => {
+  const previousFetch = globalThis.fetch;
+  let cancelled = false;
+  let timeout;
+  globalThis.fetch = async () => new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(sse([
+        { data: { type: 'response.output_text.delta', delta: 'Terminal Codex answer' } },
+        { data: { type: 'response.done', response: { output: [
+          { type: 'web_search_call', id: 'ws_terminal', status: 'completed', action: { type: 'search', query: 'terminal query' } },
+        ] } } },
+      ])));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  }), {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+
+  try {
+    const result = await Promise.race([
+      callApiStream(mockCtx(OPENAI_CODEX_TOKEN), {
+        id: 'gpt-5.5',
+        provider: 'openai-codex',
+        api: 'openai-codex-responses',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        headers: {},
+      }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] }),
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => reject(new Error('Codex stream did not stop')), 250);
+      }),
+    ]);
+
+    assert.equal(result.text, 'Terminal Codex answer');
+    assert.deepEqual(result.searchQueries, ['terminal query']);
+    assert.equal(cancelled, true);
+  } finally {
+    clearTimeout(timeout);
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream rejects error events with server message', async () => {
+  const previousFetch = globalThis.fetch;
+  let cancelled = false;
+  globalThis.fetch = async () => new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(sse([
+        { data: { type: 'error', error: { message: 'Codex SSE error message' } } },
+      ])));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  }), {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+
+  try {
+    await assert.rejects(
+      callApiStream(mockCtx(OPENAI_CODEX_TOKEN), {
+        id: 'gpt-5.5',
+        provider: 'openai-codex',
+        api: 'openai-codex-responses',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        headers: {},
+      }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] }),
+      /Codex SSE error message/,
+    );
+    assert.equal(cancelled, true);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream rejects response.failed with server message', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => makeResponse([
+    { data: { type: 'response.failed', response: { error: { message: 'Codex response failed message' } } } },
+    { data: { type: 'response.done', response: { output: [] } } },
+  ]);
+
+  try {
+    await assert.rejects(
+      callApiStream(mockCtx(OPENAI_CODEX_TOKEN), {
+        id: 'gpt-5.5',
+        provider: 'openai-codex',
+        api: 'openai-codex-responses',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        headers: {},
+      }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] }),
+      /Codex response failed message/,
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream preserves custom headers over defaults', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    assert.equal(init.headers.authorization, 'Bearer explicit-auth');
+    assert.equal(init.headers['chatgpt-account-id'], 'explicit-account');
+    assert.equal(init.headers.originator, 'custom-originator');
+    assert.equal(init.headers['openai-beta'], 'custom-beta');
+    assert.equal(init.headers.accept, 'application/x-test-stream');
+    assert.equal(Object.keys(init.headers).filter((key) => key.toLowerCase() === 'originator').length, 1);
+    return makeResponse([
+      { data: { type: 'response.output_text.delta', delta: 'Custom headers preserved' } },
+      { data: { type: 'response.done', response: { output: [] } } },
+    ]);
+  };
+
+  try {
+    const result = await callApiStream(mockCtx(OPENAI_CODEX_TOKEN, undefined, {
+      authorization: 'Bearer explicit-auth',
+      'ChatGPT-Account-ID': 'explicit-account',
+      'openai-beta': 'custom-beta',
+      accept: 'application/x-test-stream',
+    }), {
+      id: 'gpt-5.5',
+      provider: 'openai-codex',
+      api: 'openai-codex-responses',
+      baseUrl: 'https://chatgpt.com/backend-api',
+      reasoning: true,
+      headers: { Originator: 'custom-originator' },
+    }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] });
+
+    assert.equal(result.text, 'Custom headers preserved');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream accepts headers-only authentication', async () => {
+  const previousFetch = globalThis.fetch;
+  let fetched = false;
+  globalThis.fetch = async (_url, init) => {
+    fetched = true;
+    assert.equal(init.headers.authorization, 'Bearer headers-only-token');
+    assert.equal(init.headers['chatgpt-account-id'], 'headers-only-account');
+    return makeResponse([
+      { data: { type: 'response.output_text.delta', delta: 'Headers-only auth accepted' } },
+      { data: { type: 'response.done', response: { output: [] } } },
+    ]);
+  };
+
+  try {
+    const result = await callApiStream(mockCtx(undefined, undefined, {
+      authorization: 'Bearer headers-only-token',
+      'ChatGPT-Account-ID': 'headers-only-account',
+    }), {
+      id: 'gpt-5.5',
+      provider: 'openai-codex',
+      api: 'openai-codex-responses',
+      baseUrl: 'https://chatgpt.com/backend-api',
+      reasoning: true,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] });
+
+    assert.equal(fetched, true);
+    assert.equal(result.text, 'Headers-only auth accepted');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream normalizes mixed-case Authorization with auth headers winning', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    const authorizationKeys = Object.keys(init.headers).filter((key) => key.toLowerCase() === 'authorization');
+    assert.deepEqual(authorizationKeys, ['authorization']);
+    assert.equal(init.headers.authorization, 'Bearer auth-oauth-token');
+    assert.doesNotMatch(init.headers.authorization, /model-stale-token/);
+    return makeResponse([
+      { data: { type: 'response.done', response: { output: [] } } },
+    ]);
+  };
+
+  try {
+    await callApiStream(mockCtx(undefined, undefined, {
+      authorization: 'Bearer auth-oauth-token',
+      'ChatGPT-Account-ID': 'collision-account',
+    }), {
+      id: 'gpt-5.5',
+      provider: 'openai-codex',
+      api: 'openai-codex-responses',
+      baseUrl: 'https://chatgpt.com/backend-api',
+      reasoning: true,
+      headers: { Authorization: 'Bearer model-stale-token' },
+    }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream rejects missing authentication', async () => {
+  const previousFetch = globalThis.fetch;
+  let fetched = false;
+  globalThis.fetch = async () => {
+    fetched = true;
+    return makeResponse([]);
+  };
+
+  try {
+    await assert.rejects(
+      callApiStream(mockCtx(undefined), {
+        id: 'gpt-5.5',
+        provider: 'openai-codex',
+        api: 'openai-codex-responses',
+        baseUrl: 'https://chatgpt.com/backend-api',
+        reasoning: true,
+        headers: {},
+      }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] }),
+      /No OAuth credential configured for openai-codex model/,
+    );
+    assert.equal(fetched, false);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream preserves partial results from incomplete responses', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => makeResponse([
+    { data: { type: 'response.web_search_call.in_progress', item_id: 'ws_codex_partial' } },
+    { data: { type: 'response.output_text.delta', delta: 'Partial Codex answer' } },
+    { data: { type: 'response.incomplete', response: {
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: [
+        { type: 'web_search_call', id: 'ws_codex_partial', status: 'completed', action: { type: 'search', query: 'partial Codex query' } },
+      ],
+    } } },
+  ]);
+
+  try {
+    const result = await callApiStream(mockCtx(OPENAI_CODEX_TOKEN), {
+      id: 'gpt-5.5',
+      provider: 'openai-codex',
+      api: 'openai-codex-responses',
+      baseUrl: 'https://chatgpt.com/backend-api',
+      reasoning: true,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search with Codex' }] }] });
+
+    assert.equal(result.text, 'Partial Codex answer');
+    assert.equal(result.nativeSearchCalls.length, 1);
+    assert.equal(result.nativeSearchCalls[0].status, 'completed');
+    assert.deepEqual(result.nativeSearchCalls[0].queries, ['partial Codex query']);
+    assert.deepEqual(result.searchQueries, ['partial Codex query']);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI stream preserves partial results from incomplete responses', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => makeResponse([
+    { data: { type: 'response.web_search_call.in_progress', item_id: 'ws_partial' } },
+    { data: { type: 'response.output_text.delta', delta: 'Partial OpenAI answer' } },
+    { data: { type: 'response.incomplete', response: {
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: [
+        { type: 'web_search_call', id: 'ws_partial', status: 'completed', action: { type: 'search', query: 'partial query' } },
+      ],
+    } } },
+  ]);
+
+  try {
+    const result = await callApiStream(mockCtx(), {
+      id: 'gpt-test',
+      provider: 'openai',
+      api: 'openai-responses',
+      baseUrl: 'https://api.openai.com/v1',
+      reasoning: false,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search with OpenAI' }] }] });
+
+    assert.equal(result.text, 'Partial OpenAI answer');
+    assert.equal(result.nativeSearchCalls.length, 1);
+    assert.equal(result.nativeSearchCalls[0].status, 'completed');
+    assert.deepEqual(result.nativeSearchCalls[0].queries, ['partial query']);
+    assert.deepEqual(result.searchQueries, ['partial query']);
   } finally {
     globalThis.fetch = previousFetch;
   }
@@ -205,6 +565,26 @@ test('getModel does not fall back to another configured supported model', async 
   assert.match(result.content[0].text, /gpt-test/);
   assert.equal(result.details.error, 'unsupported_model');
   assert.deepEqual(result.details.availableSupportedModels, ['gpt-test (proxy-provider/openai-responses)']);
+});
+
+test('getModel accepts openai-codex Responses models', async () => {
+  const model = {
+    id: 'gpt-5.5',
+    provider: 'openai-codex',
+    api: 'openai-codex-responses',
+    baseUrl: 'https://chatgpt.com/backend-api',
+    headers: {},
+  };
+  const ctx = {
+    model,
+    modelRegistry: {
+      getAvailable() {
+        return [model];
+      },
+    },
+  };
+
+  assert.equal(await getModel(ctx), model);
 });
 
 test('getWebSearchModel prefers explicit config over current conversation model', async () => {


### PR DESCRIPTION
## Summary

Add OpenAI Codex support through the Codex Responses API.

## What changed

- Recognize `openai-codex-responses` as a supported OpenAI provider.
- Route Codex models to the Codex Responses endpoint.
- Build Codex-compatible request bodies for web search.
- Resolve OAuth authentication from either `apiKey` or supplied headers.
- Derive `chatgpt-account-id` from Codex JWT credentials when needed.
- Preserve caller-provided headers while applying Codex defaults safely.
- Handle Codex SSE lifecycle events:
  - return on terminal events without waiting for EOF
  - preserve partial results from incomplete responses
  - reject `error` and `response.failed` events with server messages
  - cancel interrupted streams during cleanup
- Merge streaming and final web-search call metadata by item ID.
- Document OpenAI Codex as a supported provider.

## Test coverage

Added regression coverage for:

- Codex request URL, headers, and request body
- Base64URL JWT account-id extraction
- Header-only OAuth authentication and case-insensitive header precedence
- Terminal SSE handling and stream cancellation
- SSE error and failed-response handling
- Partial results from incomplete responses
- Native web-search metadata deduplication
- Existing OpenAI Responses incomplete-response behavior

## Notes

This change is scoped to the new `openai-codex-responses` transport and preserves existing `openai-responses` request behavior.