### PR TITLE
Adds GitHub Copilot Business/Enterprise endpoint routing for OpenAI Responses models such as gpt-5.6-sol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Search the web using your currently selected model. Automatically picks the righ
 | OpenAI Codex | Codex Responses API web search |
 | Anthropic | Messages API web search |
 
+GitHub Copilot OpenAI Responses models are supported, including Business and Enterprise seats whose API endpoint is resolved from their authenticated Copilot credentials. This includes models such as `gpt-5.6-sol`.
+
 Supports passing up to 20 additional URLs to analyze alongside the query.
 
 ### `url_context`

--- a/src/api.ts
+++ b/src/api.ts
@@ -49,7 +49,7 @@ export function getConfig(model: Model<Api>): ProviderConfig {
 // --- Auth Compatibility Layer ---
 
 type ResolvedAuth = 
-    | { ok: true; apiKey?: string; headers?: Record<string, string>; }
+    | { ok: true; apiKey?: string; headers?: Record<string, string>; baseUrl?: string; }
     | { ok: false; error: string; };
 
 function getEnvAuth(model: Model<Api>): Extract<ResolvedAuth, { ok: true }> | undefined {
@@ -240,8 +240,47 @@ function isOpenAICodexModel(model: Model<Api>): boolean {
     return model.api === "openai-codex-responses";
 }
 
-function resolveOpenAIResponsesUrl(model: Model<Api>): string {
-    const base = trimTrailingSlash(model.baseUrl);
+function resolveGitHubCopilotBaseUrl(
+    model: Model<Api>,
+    auth: Extract<ResolvedAuth, { ok: true }>,
+): string {
+    if (model.provider !== "github-copilot") return model.baseUrl;
+
+    // Modern pi versions expose the credential-specific Copilot endpoint
+    // resolved by the provider. Prefer it so GitHub Enterprise Server and any
+    // future provider-owned routing continue to work without token parsing here.
+    if (typeof auth.baseUrl === "string" && auth.baseUrl.trim()) {
+        return auth.baseUrl;
+    }
+
+    // Compatibility fallback for older pi versions whose extension auth API
+    // returned the Copilot token but not its resolved base URL.
+    if (!auth.apiKey) return model.baseUrl;
+    const proxyEndpoints = auth.apiKey
+        .split(";")
+        .filter((field) => field.startsWith("proxy-ep="))
+        .map((field) => field.slice("proxy-ep=".length));
+    if (proxyEndpoints.length !== 1) return model.baseUrl;
+
+    const proxyHost = proxyEndpoints[0].toLowerCase();
+    const labels = proxyHost.split(".");
+    const isValidLabel = (label: string) =>
+        label.length > 0
+        && label.length <= 63
+        && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label);
+    const isCopilotProxyHost = proxyHost.length <= 253
+        && labels.length >= 4
+        && labels[0] === "proxy"
+        && labels.at(-2) === "githubcopilot"
+        && labels.at(-1) === "com"
+        && labels.every(isValidLabel);
+    if (!isCopilotProxyHost) return model.baseUrl;
+
+    return `https://api.${labels.slice(1).join(".")}`;
+}
+
+function resolveOpenAIResponsesUrl(model: Model<Api>, baseUrl = model.baseUrl): string {
+    const base = trimTrailingSlash(baseUrl);
     if (!isOpenAICodexModel(model)) return `${base}/responses`;
     if (base.endsWith("/codex/responses")) return base;
     if (base.endsWith("/codex")) return `${base}/responses`;
@@ -661,7 +700,8 @@ async function callOpenAIStream(
         requestBody.parallel_tool_calls = true;
     }
 
-    const response = await fetch(resolveOpenAIResponsesUrl(model), {
+    const baseUrl = resolveGitHubCopilotBaseUrl(model, auth);
+    const response = await fetch(resolveOpenAIResponsesUrl(model, baseUrl), {
         method: "POST",
         headers: requestHeaders,
         body: JSON.stringify(requestBody),

--- a/tests/api-parsing.test.mjs
+++ b/tests/api-parsing.test.mjs
@@ -22,13 +22,13 @@ function sse(events) {
   }).join('');
 }
 
-function mockCtx(apiKey, model = undefined, headers = undefined) {
+function mockCtx(apiKey, model = undefined, headers = undefined, baseUrl = undefined) {
   const resolvedApiKey = arguments.length === 0 ? 'test-key' : apiKey;
   return {
     model,
     modelRegistry: {
       async getApiKeyAndHeaders() {
-        return { ok: true, apiKey: resolvedApiKey, headers };
+        return { ok: true, apiKey: resolvedApiKey, headers, baseUrl };
       },
       getAvailable() {
         return model ? [model] : [];
@@ -43,6 +43,130 @@ function makeResponse(events) {
     headers: { 'content-type': 'text/event-stream' },
   });
 }
+
+function makeCopilotResponsesModel() {
+  return {
+    id: 'gpt-5.6-sol',
+    provider: 'github-copilot',
+    api: 'openai-responses',
+    baseUrl: 'https://api.individual.githubcopilot.com',
+    reasoning: true,
+    headers: {},
+  };
+}
+
+function makeMinimalOpenAIResponse() {
+  return makeResponse([
+    { data: { type: 'response.done', response: { output: [] } } },
+  ]);
+}
+
+test('GitHub Copilot Responses uses the credential-specific base URL exposed by pi', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    assert.equal(url, 'https://api.business.githubcopilot.com/responses');
+    assert.equal(init.headers.authorization, 'Bearer copilot-token');
+    assert.equal(JSON.parse(init.body).model, 'gpt-5.6-sol');
+    return makeMinimalOpenAIResponse();
+  };
+
+  try {
+    await callApiStream(
+      mockCtx('copilot-token', undefined, undefined, 'https://api.business.githubcopilot.com'),
+      makeCopilotResponsesModel(),
+      { contents: [{ parts: [{ text: 'Search with Copilot' }] }] },
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('GitHub Copilot Responses derives Business and Individual endpoints from older pi tokens', async () => {
+  const previousFetch = globalThis.fetch;
+  const expectedUrls = [
+    'https://api.business.githubcopilot.com/responses',
+    'https://api.individual.githubcopilot.com/responses',
+  ];
+  let requestIndex = 0;
+  globalThis.fetch = async (url) => {
+    assert.equal(url, expectedUrls[requestIndex++]);
+    return makeMinimalOpenAIResponse();
+  };
+
+  try {
+    for (const proxyEndpoint of [
+      'proxy.business.githubcopilot.com',
+      'proxy.individual.githubcopilot.com',
+    ]) {
+      await callApiStream(
+        mockCtx(`tid=test;proxy-ep=${proxyEndpoint};exp=9999999999`),
+        makeCopilotResponsesModel(),
+        { contents: [{ parts: [{ text: 'Search with Copilot' }] }] },
+      );
+    }
+    assert.equal(requestIndex, expectedUrls.length);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('GitHub Copilot Responses rejects unsafe proxy endpoints and falls back to the model URL', async () => {
+  const previousFetch = globalThis.fetch;
+  const unsafeTokens = [
+    'tid=test;exp=9999999999',
+    'tid=test;proxy-ep=evil.example.com;exp=9999999999',
+    'tid=test;proxy-ep=proxy.business.githubcopilot.com.evil.example;exp=9999999999',
+    'tid=test;proxy-ep=proxy.business.githubcopilot.com/path;exp=9999999999',
+    'tid=test;proxy-ep=proxy.business.githubcopilot.com:443;exp=9999999999',
+    'tid=test;proxy-ep=https://proxy.business.githubcopilot.com;exp=9999999999',
+    'tid=test;proxy-ep=proxy.business.githubcopilot.com;proxy-ep=proxy.individual.githubcopilot.com;exp=9999999999',
+  ];
+  let requestCount = 0;
+  globalThis.fetch = async (url) => {
+    requestCount++;
+    assert.equal(url, 'https://api.individual.githubcopilot.com/responses');
+    return makeMinimalOpenAIResponse();
+  };
+
+  try {
+    for (const token of unsafeTokens) {
+      await callApiStream(
+        mockCtx(token),
+        makeCopilotResponsesModel(),
+        { contents: [{ parts: [{ text: 'Search with Copilot' }] }] },
+      );
+    }
+    assert.equal(requestCount, unsafeTokens.length);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('non-Copilot Responses ignores proxy endpoint text in its API key', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    assert.equal(url, 'https://example.test/v1/responses');
+    return makeMinimalOpenAIResponse();
+  };
+
+  try {
+    await callApiStream(mockCtx(
+      'tid=test;proxy-ep=proxy.business.githubcopilot.com;exp=9999999999',
+      undefined,
+      undefined,
+      'https://api.business.githubcopilot.com',
+    ), {
+      id: 'gpt-test',
+      provider: 'openai',
+      api: 'openai-responses',
+      baseUrl: 'https://example.test/v1',
+      reasoning: false,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search with OpenAI' }] }] });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
 
 test('OpenAI stream exposes native search calls, queries, URLs, and citations', async () => {
   const previousFetch = globalThis.fetch;


### PR DESCRIPTION
 Addresses #16 for GitHub Copilot Business/Enterprise OpenAI Responses models, including gpt-5.6-sol.

 The original issue was primarily a Pi limitation: extensions received the Copilot token but not its
 credential-specific API endpoint. Modern Pi now exposes that endpoint as auth.baseUrl, but pi-web-search
 constructs requests manually and does not yet use it.

 This PR:

 - uses Pi’s resolved auth.baseUrl for Copilot Responses requests;
 - falls back to validated proxy-ep parsing for older supported Pi versions;
 - rejects malformed or unsafe fallback hostnames;
 - leaves Anthropic and non-Copilot providers unchanged.

 Testing

 ```text
   npm test          # 29/29 passing
   npx tsc --noEmit  # passing
 ```

 Also verified end-to-end with github-copilot/gpt-5.6-sol: native web search completed successfully and
 returned grounded source URLs without HTTP 421.