### PR TITLE
Collapse web search output by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,15 @@
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.3",
         "@earendil-works/pi-coding-agent": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
         "@types/node": "^25.9.1",
         "typebox": "^1.1.38",
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-ai": ">=0.80.3",
+        "@earendil-works/pi-coding-agent": ">=0.80.3",
+        "@earendil-works/pi-tui": "*",
         "typebox": "*"
       }
     },
@@ -2515,6 +2517,20 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
@@ -3019,6 +3035,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -3128,6 +3157,19 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.80.3",
     "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3",
     "@types/node": "^25.9.1",
     "typebox": "^1.1.38",
     "typescript": "^6.0.3"
@@ -51,6 +52,7 @@
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.3",
     "@earendil-works/pi-coding-agent": ">=0.80.3",
+    "@earendil-works/pi-tui": "*",
     "typebox": "*"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { Text } from "@earendil-works/pi-tui";
 import { getProviderKind } from "./api.ts";
 import { webSearch, WebSearchSchema } from "./web_search.ts";
 import { urlContext, UrlContextSchema } from "./url_context.ts";
@@ -64,7 +65,28 @@ export default function (pi: ExtensionAPI) {
         label: "Web Search",
         description: "Search the web using the current supported provider (Google Gemini, OpenAI, or Anthropic). Optionally include URLs to analyze alongside search results.",
         parameters: WebSearchSchema,
-        execute: webSearch
+        execute: webSearch,
+        renderCall(args, theme) {
+            const query = args.query || "…";
+            const urlCount = args.urls?.length ?? 0;
+            const urls = urlCount > 0 ? theme.fg("muted", ` + ${urlCount} URL${urlCount === 1 ? "" : "s"}`) : "";
+            return new Text(
+                `${theme.fg("toolTitle", theme.bold("web_search"))} ${theme.fg("accent", query)}${urls}`,
+                0,
+                0,
+            );
+        },
+        renderResult(result, { expanded }, theme) {
+            const output = result.content
+                .filter((part) => part.type === "text")
+                .map((part) => part.text)
+                .join("\n");
+
+            const isError = Boolean(result.details?.error);
+            if (!expanded && !isError) return new Text("", 0, 0);
+
+            return new Text(theme.fg(isError ? "error" : "toolOutput", output), 0, 0);
+        }
     });
 
     pi.registerTool({

--- a/tests/rendering.test.mjs
+++ b/tests/rendering.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import registerExtension from "../src/index.ts";
+
+function getWebSearchTool() {
+    const tools = new Map();
+    registerExtension({
+        registerTool(tool) {
+            tools.set(tool.name, tool);
+        },
+        getActiveTools() {
+            return [];
+        },
+        setActiveTools() {},
+        on() {},
+    });
+    return tools.get("web_search");
+}
+
+const theme = {
+    fg(_color, text) {
+        return text;
+    },
+    bold(text) {
+        return text;
+    },
+};
+
+test("web_search call shows the query and URL count", () => {
+    const tool = getWebSearchTool();
+    const component = tool.renderCall(
+        { query: "latest pi release", urls: ["https://pi.dev", "https://github.com"] },
+        theme,
+    );
+
+    assert.deepEqual(component.render(80).map((line) => line.trimEnd()), [
+        "web_search latest pi release + 2 URLs",
+    ]);
+});
+
+test("web_search hides successful output when collapsed", () => {
+    const tool = getWebSearchTool();
+    const component = tool.renderResult(
+        { content: [{ type: "text", text: "search result" }], details: {} },
+        { expanded: false, isPartial: false },
+        theme,
+    );
+
+    assert.deepEqual(component.render(80), []);
+});
+
+test("web_search shows successful output when expanded", () => {
+    const tool = getWebSearchTool();
+    const component = tool.renderResult(
+        { content: [{ type: "text", text: "search result" }], details: {} },
+        { expanded: true, isPartial: false },
+        theme,
+    );
+
+    assert.deepEqual(component.render(80).map((line) => line.trimEnd()), ["search result"]);
+});
+
+test("web_search keeps errors visible when collapsed", () => {
+    const tool = getWebSearchTool();
+    const component = tool.renderResult(
+        { content: [{ type: "text", text: "Error: unavailable" }], details: { error: true } },
+        { expanded: false, isPartial: false },
+        theme,
+    );
+
+    assert.deepEqual(component.render(80).map((line) => line.trimEnd()), ["Error: unavailable"]);
+});


### PR DESCRIPTION
I found the default output of web_search too be too verbose, making it harder to navigate through session history.
This PR hides collapses the output and only shows search terms by default (see screenshot), unless expanded.

Note that it adds pi-tui to peer dependencies, which is probably fine for most people but may concern the folks not using the tui?

Screenshot

<img width="1020" height="455" alt="Screenshot 2026-08-12 at 15 10 57" src="https://github.com/user-attachments/assets/d8431a5a-bc8e-498c-82fe-20d474786733" />
