### PR TITLE
feat: add adaptive web search depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ Search the web using your currently selected model. Automatically picks the righ
 | OpenAI Codex | Codex Responses API web search |
 | Anthropic | Messages API web search |
 
-Supports passing up to 20 additional URLs to analyze alongside the query.
+Supports passing up to 20 additional URLs to analyze alongside the query. The optional `depth` parameter adapts research thoroughness and OpenAI/Codex reasoning effort:
+
+| Depth | OpenAI/Codex reasoning effort | Use case |
+|---|---|---|
+| `quick` | `none` | Simple lookups |
+| `standard` (default) | `low` | Normal searches |
+| `deep` | `medium` | Product research, multi-source comparisons, and thorough investigations |
+
+The depth guidance is included in the search prompt for every provider. Reasoning effort is currently applied only to reasoning-capable OpenAI/Codex models.
 
 ### `url_context`
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,6 +7,12 @@ import { TextEncoder, TextDecoder } from "util";
 
 type ProviderKind = "google" | "openai" | "anthropic" | "unsupported";
 
+export type OpenAIReasoningEffort = "none" | "low" | "medium";
+
+export interface CallApiStreamOptions {
+    reasoningEffort?: OpenAIReasoningEffort;
+}
+
 type GoogleRequestBuilder = (model: Model<Api>, body: any) => { url: string; headers: Record<string, string>; body: any };
 
 type ProviderConfig = {
@@ -608,7 +614,8 @@ async function callOpenAIStream(
     model: Model<Api>,
     prompt: string,
     onUpdate?: AgentToolUpdateCallback,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    options?: CallApiStreamOptions
 ): Promise<StreamResult> {
     const auth = await getAuth(ctx, model);
     if (!auth.ok) {
@@ -652,7 +659,7 @@ async function callOpenAIStream(
         store: false,
     };
     if (model.reasoning) {
-        requestBody.reasoning = { effort: "none" };
+        requestBody.reasoning = { effort: options?.reasoningEffort ?? "none" };
     }
     if (isCodex) {
         requestBody.instructions = "Answer the user's request using web search when needed.";
@@ -981,7 +988,8 @@ export async function callApiStream(
     model: Model<Api>,
     body: any,
     onUpdate?: AgentToolUpdateCallback,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    options?: CallApiStreamOptions
 ): Promise<StreamResult> {
     const kind = getProviderKind(model);
     if (kind === "google") {
@@ -994,7 +1002,7 @@ export async function callApiStream(
     }
 
     if (kind === "openai") {
-        return callOpenAIStream(ctx, model, prompt, onUpdate, signal);
+        return callOpenAIStream(ctx, model, prompt, onUpdate, signal, options);
     }
     if (kind === "anthropic") {
         return callAnthropicStream(ctx, model, prompt, onUpdate, signal);

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,10 @@ export default function (pi: ExtensionAPI) {
     pi.registerTool({
         name: WEB_SEARCH_TOOL,
         label: "Web Search",
-        description: "Search the web using the current supported provider (Google Gemini, OpenAI, or Anthropic). Optionally include URLs to analyze alongside search results.",
+        description: "Search the web using the current supported provider (Google Gemini, OpenAI, or Anthropic). Optionally include URLs and choose quick, standard, or deep research depth.",
+        promptGuidelines: [
+            "For web_search, use depth quick for simple lookups, standard for normal searches, and deep for product research, multi-source comparisons, or other thorough investigations."
+        ],
         parameters: WebSearchSchema,
         execute: webSearch
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getProviderKind } from "./api.ts";
-import { webSearch, WebSearchSchema } from "./web_search.ts";
+import { prepareWebSearchArguments, webSearch, WebSearchSchema } from "./web_search.ts";
 import { urlContext, UrlContextSchema } from "./url_context.ts";
 
 const WEB_SEARCH_TOOL = "web_search";
@@ -67,6 +67,7 @@ export default function (pi: ExtensionAPI) {
             "For web_search, use depth quick for simple lookups, standard for normal searches, and deep for product research, multi-source comparisons, or other thorough investigations."
         ],
         parameters: WebSearchSchema,
+        prepareArguments: prepareWebSearchArguments,
         execute: webSearch
     });
 

--- a/src/web_search.ts
+++ b/src/web_search.ts
@@ -10,13 +10,22 @@ export const WebSearchSchema = Type.Object({
         description: "Additional URLs to analyze along with search (up to 20)",
         maxItems: 20
     })),
-    depth: Type.Optional(StringEnum(["quick", "standard", "deep"] as const, {
-        description: "Research depth. quick is a simple lookup, standard is the default balanced search, and deep performs more thorough multi-source research.",
-        default: "standard"
-    })),
+    depth: StringEnum(["quick", "standard", "deep"] as const, {
+        description: "Research depth. Use quick for simple lookups, standard for normal searches, and deep for product research, multi-source comparisons, or thorough investigations."
+    }),
 });
 export type WebSearchInput = Static<typeof WebSearchSchema>;
-export type SearchDepth = NonNullable<WebSearchInput["depth"]>;
+export type SearchDepth = WebSearchInput["depth"];
+
+export function prepareWebSearchArguments(args: unknown): WebSearchInput {
+    const input = args && typeof args === "object" && !Array.isArray(args)
+        ? args as Record<string, unknown>
+        : {};
+    return {
+        ...input,
+        depth: input.depth === undefined ? "standard" : input.depth,
+    } as WebSearchInput;
+}
 
 export interface SearchDepthSettings {
     depth: SearchDepth;

--- a/src/web_search.ts
+++ b/src/web_search.ts
@@ -1,6 +1,7 @@
 import type { ExtensionContext, AgentToolUpdateCallback } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "typebox";
-import { callApiStream, getConfig, applyCitations } from "./api.ts";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { callApiStream, getConfig, applyCitations, type OpenAIReasoningEffort } from "./api.ts";
 import { getWebSearchModel, missingWebSearchConfigResult, errorResult, formatResult } from "./utils.ts";
 
 export const WebSearchSchema = Type.Object({
@@ -9,8 +10,42 @@ export const WebSearchSchema = Type.Object({
         description: "Additional URLs to analyze along with search (up to 20)",
         maxItems: 20
     })),
+    depth: Type.Optional(StringEnum(["quick", "standard", "deep"] as const, {
+        description: "Research depth. quick is a simple lookup, standard is the default balanced search, and deep performs more thorough multi-source research.",
+        default: "standard"
+    })),
 });
 export type WebSearchInput = Static<typeof WebSearchSchema>;
+export type SearchDepth = NonNullable<WebSearchInput["depth"]>;
+
+export interface SearchDepthSettings {
+    depth: SearchDepth;
+    reasoningEffort: OpenAIReasoningEffort;
+    instruction: string;
+}
+
+export function getSearchDepthSettings(depth: WebSearchInput["depth"]): SearchDepthSettings {
+    switch (depth ?? "standard") {
+        case "quick":
+            return {
+                depth: "quick",
+                reasoningEffort: "none",
+                instruction: "Perform a concise lookup using the minimum search needed to answer accurately. Prefer a primary source when available."
+            };
+        case "deep":
+            return {
+                depth: "deep",
+                reasoningEffort: "medium",
+                instruction: "Conduct thorough multi-source research. Prioritize primary sources, compare conflicting evidence, and clearly distinguish verified facts from uncertainty."
+            };
+        default:
+            return {
+                depth: "standard",
+                reasoningEffort: "low",
+                instruction: "Perform a balanced search using authoritative sources and verify important claims across sources when practical."
+            };
+    }
+}
 
 export async function webSearch(
     id: string, 
@@ -24,6 +59,7 @@ export async function webSearch(
 
     const hasUrls = params.urls && params.urls.length > 0;
     const urlCount = hasUrls ? params.urls!.length : 0;
+    const depthSettings = getSearchDepthSettings(params.depth);
     
     onUpdate?.({ 
         content: [{ 
@@ -39,9 +75,10 @@ export async function webSearch(
         const config = getConfig(model);
         
         // Build prompt: include URLs if provided
-        const prompt = hasUrls
+        const request = hasUrls
             ? `${params.query}\n\nAlso analyze these URLs:\n${params.urls!.join("\n")}`
             : params.query;
+        const prompt = `${request}\n\nResearch guidance: ${depthSettings.instruction}`;
 
         // Enable provider-native search tools. Google needs explicit Gemini tool names;
         // OpenAI/Anthropic are handled inside callApiStream based on the current model.
@@ -54,7 +91,7 @@ export async function webSearch(
         const result = await callApiStream(ctx, model, {
             contents: [{ role: "user", parts: [{ text: prompt }] }],
             ...(tools ? { tools } : {})
-        }, onUpdate, signal);
+        }, onUpdate, signal, { reasoningEffort: depthSettings.reasoningEffort });
 
         const cited = applyCitations(result.text, result.groundingMetadata);
         const text = cited.text;
@@ -114,6 +151,8 @@ export async function webSearch(
             retrieved: retrieved.length > 0 ? retrieved : undefined,
             failed: failed.length > 0 ? failed : undefined,
             model: model.id,
+            depth: depthSettings.depth,
+            reasoningEffort: depthSettings.reasoningEffort,
             grounded: sources.length > 0 || (result.searchResults?.length || 0) > 0,
             resultCount: result.searchResults?.length || sources.length
         });

--- a/tests/api-parsing.test.mjs
+++ b/tests/api-parsing.test.mjs
@@ -7,7 +7,7 @@ import { callApiStream } from '../src/api.ts';
 import { createModelScopedToolManager } from '../src/index.ts';
 import { getModel, getWebSearchModel, missingConfigResult, missingWebSearchConfigResult } from '../src/utils.ts';
 import { urlContext } from '../src/url_context.ts';
-import { webSearch } from '../src/web_search.ts';
+import { getSearchDepthSettings, webSearch } from '../src/web_search.ts';
 
 const OPENAI_CODEX_TOKEN = [
   'eyJhbGciOiJub25lIn0',
@@ -43,6 +43,21 @@ function makeResponse(events) {
     headers: { 'content-type': 'text/event-stream' },
   });
 }
+
+test('search depth maps to adaptive reasoning effort with standard as the default', () => {
+  assert.deepEqual(
+    { ...getSearchDepthSettings('quick'), instruction: undefined },
+    { depth: 'quick', reasoningEffort: 'none', instruction: undefined },
+  );
+  assert.deepEqual(
+    { ...getSearchDepthSettings(undefined), instruction: undefined },
+    { depth: 'standard', reasoningEffort: 'low', instruction: undefined },
+  );
+  assert.deepEqual(
+    { ...getSearchDepthSettings('deep'), instruction: undefined },
+    { depth: 'deep', reasoningEffort: 'medium', instruction: undefined },
+  );
+});
 
 test('OpenAI stream exposes native search calls, queries, URLs, and citations', async () => {
   const previousFetch = globalThis.fetch;
@@ -148,6 +163,7 @@ test('OpenAI Codex stream uses Codex Responses transport with native web search'
     assert.deepEqual(body.include, ['web_search_call.action.sources']);
     assert.equal(body.tool_choice, 'required');
     assert.equal(body.parallel_tool_calls, true);
+    assert.deepEqual(body.reasoning, { effort: 'none' });
     assert.equal(body.stream, true);
     assert.equal(body.store, false);
 
@@ -178,6 +194,35 @@ test('OpenAI Codex stream uses Codex Responses transport with native web search'
     assert.equal(result.nativeSearchCalls.length, 1);
     assert.equal(result.nativeSearchCalls[0].status, 'completed');
     assert.deepEqual(result.nativeSearchCalls[0].queries, ['Codex web search']);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('OpenAI Codex stream honors requested reasoning effort', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    const body = JSON.parse(init.body);
+    assert.deepEqual(body.reasoning, { effort: 'medium' });
+    return makeResponse([
+      { data: { type: 'response.output_text.delta', delta: 'Deep search answer' } },
+      { data: { type: 'response.done', response: { output: [] } } },
+    ]);
+  };
+
+  try {
+    const result = await callApiStream(mockCtx(OPENAI_CODEX_TOKEN), {
+      id: 'gpt-5.6-terra',
+      provider: 'openai-codex',
+      api: 'openai-codex-responses',
+      baseUrl: 'https://chatgpt.com/backend-api',
+      reasoning: true,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Deep product research' }] }] }, undefined, undefined, {
+      reasoningEffort: 'medium',
+    });
+
+    assert.equal(result.text, 'Deep search answer');
   } finally {
     globalThis.fetch = previousFetch;
   }

--- a/tests/api-parsing.test.mjs
+++ b/tests/api-parsing.test.mjs
@@ -7,7 +7,7 @@ import { callApiStream } from '../src/api.ts';
 import { createModelScopedToolManager } from '../src/index.ts';
 import { getModel, getWebSearchModel, missingConfigResult, missingWebSearchConfigResult } from '../src/utils.ts';
 import { urlContext } from '../src/url_context.ts';
-import { getSearchDepthSettings, webSearch } from '../src/web_search.ts';
+import { getSearchDepthSettings, prepareWebSearchArguments, webSearch } from '../src/web_search.ts';
 
 const OPENAI_CODEX_TOKEN = [
   'eyJhbGciOiJub25lIn0',
@@ -43,6 +43,17 @@ function makeResponse(events) {
     headers: { 'content-type': 'text/event-stream' },
   });
 }
+
+test('legacy web_search calls without depth are prepared as standard searches', () => {
+  assert.deepEqual(
+    prepareWebSearchArguments({ query: 'legacy search' }),
+    { query: 'legacy search', depth: 'standard' },
+  );
+  assert.deepEqual(
+    prepareWebSearchArguments({ query: 'deep search', depth: 'deep' }),
+    { query: 'deep search', depth: 'deep' },
+  );
+});
 
 test('search depth maps to adaptive reasoning effort with standard as the default', () => {
   assert.deepEqual(


### PR DESCRIPTION
## Summary

Adds an optional `depth` parameter to `web_search`:

- `quick` → OpenAI/Codex reasoning effort `none`
- `standard` (default) → `low`
- `deep` → `medium`

The selected depth also adds provider-neutral research guidance so Gemini and Anthropic searches get the same quick/standard/deep intent even though reasoning effort is only sent to reasoning-capable OpenAI/Codex models.

## Motivation

Simple lookups should stay fast, while product research and multi-source comparisons benefit from more deliberate query planning and synthesis. Today the extension hard-codes OpenAI reasoning effort to `none`, so callers cannot express that distinction.

## Compatibility

- Existing calls that omit `depth` remain valid and now use the balanced `standard` behavior.
- Direct internal `callApiStream` callers keep the old `none` fallback unless they pass the new option.
- No config or authentication changes.

## Verification

- `npm test` — 27 passing
- `npx tsc --noEmit` — passing
- Real Codex tests with `gpt-5.6-terra`:
  - omitted depth → `standard` / `low`, native search grounded
  - `depth: deep` → `medium`, native search grounded
