### PR TITLE
feat(deepseek): add native DeepSeek Responses web search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-web-search
 
-Provider-native web search for [pi](https://github.com/earendil-works/pi-coding-agent), across Google Gemini, OpenAI, and Anthropic, plus Gemini-only URL Context analysis.
+Provider-native web search for [pi](https://github.com/earendil-works/pi-coding-agent), across Google Gemini, OpenAI, Anthropic, and DeepSeek, plus Gemini-only URL Context analysis.
 
 ## Tools
 
@@ -14,6 +14,7 @@ Search the web using your currently selected model. Automatically picks the righ
 | OpenAI | Responses API web search |
 | OpenAI Codex | Codex Responses API web search |
 | Anthropic | Messages API web search |
+| DeepSeek | Responses API web search |
 
 GitHub Copilot OpenAI Responses models are supported, including Business and Enterprise seats whose API endpoint is resolved from their authenticated Copilot credentials. This includes models such as `gpt-5.6-sol`.
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,7 @@ import { TextEncoder, TextDecoder } from "util";
 
 // --- Provider Configuration ---
 
-type ProviderKind = "google" | "openai" | "anthropic" | "unsupported";
+type ProviderKind = "google" | "openai" | "deepseek" | "anthropic" | "unsupported";
 
 type GoogleRequestBuilder = (model: Model<Api>, body: any) => { url: string; headers: Record<string, string>; body: any };
 
@@ -32,8 +32,24 @@ const GOOGLE_PROVIDERS: Record<string, ProviderConfig> = {
     }
 };
 
+/**
+ * DeepSeek exposes a server-side web search tool through its Responses API.
+ * Pi's built-in DeepSeek models report `api: "openai-completions"`, so they
+ * cannot be recognized by the `api` field alone. Match on the model id leaf
+ * only, never on the provider name: the same DeepSeek models are hosted by
+ * `deepseek`, `opencode-go`, `opencode`, `openrouter`, etc., each with its
+ * own endpoint, and router providers may use provider-qualified ids
+ * (e.g. `deepseek/deepseek-v4-flash`).
+ */
+export function isDeepSeekResponsesModel(model: Model<Api>): boolean {
+    const id = String(model.id).toLowerCase();
+    const leaf = id.slice(id.lastIndexOf("/") + 1);
+    return leaf.startsWith("deepseek");
+}
+
 export function getProviderKind(model: Model<Api>): ProviderKind {
     if (GOOGLE_PROVIDERS[model.provider] || GOOGLE_PROVIDERS[model.api]) return "google";
+    if (isDeepSeekResponsesModel(model)) return "deepseek";
     if (model.api === "openai-responses" || model.api === "openai-codex-responses") return "openai";
     if (model.api === "anthropic-messages") return "anthropic";
     return "unsupported";
@@ -850,6 +866,157 @@ async function callOpenAIStream(
     };
 }
 
+async function callDeepSeekStream(
+    ctx: ExtensionContext,
+    model: Model<Api>,
+    prompt: string,
+    onUpdate?: AgentToolUpdateCallback,
+    signal?: AbortSignal
+): Promise<StreamResult> {
+    const auth = await getAuth(ctx, model);
+    if (!auth.ok) {
+        throw new Error(auth.error || "Failed to get API key and headers");
+    }
+
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(model.headers || {})) headers.set(name, value);
+    for (const [name, value] of Object.entries(auth.headers || {})) headers.set(name, value);
+    if (!headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+    if (!headers.has("Accept")) headers.set("Accept", "text/event-stream");
+    if (auth.apiKey && !headers.has("Authorization")) headers.set("Authorization", `Bearer ${auth.apiKey}`);
+    const requestHeaders = Object.fromEntries(headers.entries());
+
+    // DeepSeek's Responses request mirrors OpenAI, minus OpenAI-specific fields
+    // (no `include`, no Codex/Copilot transport bits). Leave `tool_choice` as
+    // auto so the model decides when a search is genuinely useful.
+    const requestBody: any = {
+        model: model.id,
+        input: prompt,
+        tools: [{ type: "web_search" }],
+        stream: true,
+        store: false,
+    };
+    if (model.reasoning) {
+        requestBody.reasoning = { effort: "none" };
+    }
+
+    const response = await fetch(resolveOpenAIResponsesUrl(model, model.baseUrl), {
+        method: "POST",
+        headers: requestHeaders,
+        body: JSON.stringify(requestBody),
+        signal
+    });
+
+    if (!response.ok) {
+        throw new Error(`DeepSeek API error (${response.status}): ${await response.text()}`);
+    }
+
+    let accumulatedText = "";
+    const nativeSearchEvents: string[] = [];
+    const nativeSearchCalls: NativeSearchCallDetail[] = [];
+    const searchQueries: string[] = [];
+    const searchResults: SearchResultDetail[] = [];
+
+    const collectWebSearchCall = (item: any) => {
+        if (item?.type !== "web_search_call") return;
+        const action = item.action || {};
+        const call: NativeSearchCallDetail = {
+            id: item.id,
+            provider: "deepseek",
+            status: item.status,
+            actionType: action.type,
+            raw: item,
+        };
+        if (Array.isArray(action.queries)) {
+            const queries = action.queries.filter((query: any): query is string => typeof query === "string");
+            call.queries = queries;
+            for (const query of queries) pushUniqueString(searchQueries, query);
+        } else if (typeof action.query === "string") {
+            call.queries = [action.query];
+            pushUniqueString(searchQueries, action.query);
+        }
+        if (Array.isArray(action.sources)) {
+            call.urls = action.sources.map((source: any) => source?.url).filter((url: any): url is string => typeof url === "string");
+            for (const source of action.sources) {
+                if (!source?.url) continue;
+                pushUniqueSearchResult(searchResults, {
+                    title: source.title || source.display_name || source.name || titleFromUrl(source.url),
+                    url: source.url,
+                    source: "deepseek.web_search_call.action.sources",
+                    type: source.type || "url",
+                    raw: source,
+                });
+            }
+        }
+        if (action.url) {
+            call.urls = [...(call.urls || []), action.url];
+            pushUniqueSearchResult(searchResults, {
+                title: titleFromUrl(action.url),
+                url: action.url,
+                source: `deepseek.web_search_call.action.${action.type}`,
+                type: action.type,
+                raw: action,
+            });
+        }
+        const existingCall = call.id ? nativeSearchCalls.find((existing) => existing.id === call.id) : undefined;
+        if (existingCall) {
+            Object.assign(existingCall, Object.fromEntries(
+                Object.entries(call).filter(([, value]) => value !== undefined)
+            ));
+        } else {
+            nativeSearchCalls.push(call);
+        }
+    };
+
+    const collectFromResponse = (response: any) => {
+        for (const item of response?.output || []) collectWebSearchCall(item);
+    };
+
+    await readSseEvents(response, signal, ({ data: event }) => {
+        if (event.type === "error" || event.type === "response.failed") {
+            const message = event.message || event.error?.message || event.response?.error?.message;
+            throw new Error(message || JSON.stringify(event.error || event.response?.error || event));
+        } else if (event.type === "response.output_text.delta") {
+            accumulatedText += event.delta || "";
+            onUpdate?.({
+                content: [{ type: "text", text: accumulatedText }],
+                details: { streaming: true }
+            });
+        } else if (event.type === "response.output_item.added" || event.type === "response.output_item.done") {
+            collectWebSearchCall(event.item);
+        } else if (event.type === "response.incomplete" || event.response?.status === "incomplete") {
+            collectFromResponse(event.response);
+        } else if (event.type === "response.completed" || event.type === "response.done") {
+            collectFromResponse(event.response);
+        } else if (event.type === "response.web_search_call.in_progress" || event.type === "response.web_search_call.searching" || event.type === "response.web_search_call.completed") {
+            pushNativeSearchEvent(nativeSearchEvents, event.type);
+            const call = nativeSearchCalls.find((item) => item.id === event.item_id);
+            if (call) call.status = event.type.replace("response.web_search_call.", "");
+            else nativeSearchCalls.push({ id: event.item_id, provider: "deepseek", status: event.type.replace("response.web_search_call.", ""), raw: event });
+            if (event.type === "response.web_search_call.searching") {
+                onUpdate?.({
+                    content: [{ type: "text", text: accumulatedText || "Searching the web with DeepSeek..." }],
+                    details: { streaming: true, searching: true }
+                });
+            }
+        }
+    });
+
+    const sanitizedSearchResults = sanitizeSearchResults(searchResults);
+
+    return {
+        text: accumulatedText || "No answer available.",
+        sources: deriveSources(sanitizedSearchResults, []),
+        providerKind: "deepseek",
+        nativeSearchUsed: nativeSearchEvents.length > 0 || nativeSearchCalls.length > 0 || sanitizedSearchResults.length > 0,
+        nativeSearchEvents,
+        nativeSearchCalls,
+        searchQueries,
+        searchResults: sanitizedSearchResults,
+        citations: [],
+    };
+}
+
 async function callAnthropicStream(
     ctx: ExtensionContext,
     model: Model<Api>,
@@ -1035,6 +1202,9 @@ export async function callApiStream(
 
     if (kind === "openai") {
         return callOpenAIStream(ctx, model, prompt, onUpdate, signal);
+    }
+    if (kind === "deepseek") {
+        return callDeepSeekStream(ctx, model, prompt, onUpdate, signal);
     }
     if (kind === "anthropic") {
         return callAnthropicStream(ctx, model, prompt, onUpdate, signal);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export function formatResult(text: string, details: any): AgentToolResult<any> {
 
 // --- Model Selection ---
 
-const SUPPORTED_PROVIDERS = ["google-generative-ai", "openai-responses", "openai-codex-responses", "anthropic-messages"];
+const SUPPORTED_PROVIDERS = ["google-generative-ai", "openai-responses", "openai-codex-responses", "anthropic-messages", "deepseek"];
 const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "agent", "web-search.json");
 
 type WebSearchModelConfig =

--- a/tests/api-parsing.test.mjs
+++ b/tests/api-parsing.test.mjs
@@ -603,6 +603,136 @@ test('OpenAI stream preserves partial results from incomplete responses', async 
   }
 });
 
+test('DeepSeek stream routes pi built-in models to the inherited Responses endpoint', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    // The modeled opencode-go provider serves DeepSeek models from its own endpoint.
+    assert.equal(url, 'https://opencode.ai/zen/go/v1/responses');
+    assert.equal(init.headers.authorization, 'Bearer test-key');
+    const body = JSON.parse(init.body);
+    assert.equal(body.model, 'deepseek-v4-flash');
+    assert.deepEqual(body.tools, [{ type: 'web_search' }]);
+    assert.equal(body.include, undefined);
+    assert.equal(body.stream, true);
+    return makeResponse([
+      { data: { type: 'response.web_search_call.in_progress', item_id: 'ws_deepseek' } },
+      { data: { type: 'response.web_search_call.searching', item_id: 'ws_deepseek' } },
+      { data: { type: 'response.output_item.added', item: { type: 'web_search_call', id: 'ws_deepseek', status: 'searching', action: { type: 'search', query: 'DeepSeek docs', queries: ['DeepSeek docs'], url: 'https://api-docs.deepseek.com' } } } },
+      { data: { type: 'response.output_text.delta', delta: 'DeepSeek supports server-side web search' } },
+      { data: { type: 'response.web_search_call.completed', item_id: 'ws_deepseek' } },
+      { data: { type: 'response.completed', response: { output: [
+        { type: 'web_search_call', id: 'ws_deepseek', status: 'completed', action: { type: 'search', queries: ['DeepSeek docs'], url: 'https://api-docs.deepseek.com' } },
+        { type: 'message', content: [{ type: 'output_text', text: 'DeepSeek supports server-side web search' }] },
+      ] } } },
+    ]);
+  };
+
+  try {
+    const result = await callApiStream(mockCtx(), {
+      id: 'deepseek-v4-flash',
+      provider: 'opencode-go',
+      api: 'openai-completions',
+      baseUrl: 'https://opencode.ai/zen/go/v1',
+      reasoning: false,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search DeepSeek docs' }] }] });
+
+    assert.equal(result.providerKind, 'deepseek');
+    assert.equal(result.nativeSearchUsed, true);
+    assert.deepEqual(result.nativeSearchEvents, [
+      'response.web_search_call.in_progress',
+      'response.web_search_call.searching',
+      'response.web_search_call.completed',
+    ]);
+    assert.deepEqual(result.searchQueries, ['DeepSeek docs']);
+    assert.equal(result.text, 'DeepSeek supports server-side web search');
+    assert.ok(result.sources.some((s) => s.url.replace(/\/$/, '') === 'https://api-docs.deepseek.com'));
+    assert.equal(result.nativeSearchCalls[0].provider, 'deepseek');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('DeepSeek stream matches models by id leaf across hosting providers', async () => {
+  const previousFetch = globalThis.fetch;
+  const requestedUrls = [];
+  globalThis.fetch = async (url) => {
+    requestedUrls.push(url);
+    return makeResponse([
+      { data: { type: 'response.output_text.delta', delta: 'ok' } },
+      { data: { type: 'response.done', response: { output: [] } } },
+    ]);
+  };
+
+  const hosts = [
+    { provider: 'deepseek', baseUrl: 'https://api.deepseek.com' },
+    { provider: 'opencode', baseUrl: 'https://opencode.ai/zen/v1' },
+    { provider: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1' },
+  ];
+
+  try {
+    for (const host of hosts) {
+      await callApiStream(mockCtx(), {
+        id: 'deepseek-v4-pro',
+        provider: host.provider,
+        api: 'openai-completions',
+        baseUrl: host.baseUrl,
+        reasoning: false,
+        headers: {},
+      }, { contents: [{ parts: [{ text: 'Search' }] }] });
+    }
+    // provider-qualified id (router-style) must match too
+    await callApiStream(mockCtx(), {
+      id: 'deepseek/deepseek-v4-flash',
+      provider: 'openrouter',
+      api: 'openai-completions',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      reasoning: false,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search' }] }] });
+
+    assert.deepEqual(requestedUrls, [
+      'https://api.deepseek.com/responses',
+      'https://opencode.ai/zen/v1/responses',
+      'https://openrouter.ai/api/v1/responses',
+      'https://openrouter.ai/api/v1/responses',
+    ]);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('DeepSeek stream falls back to env API key when resolved auth has no credential', async () => {
+  const previousFetch = globalThis.fetch;
+  const previousOpenCodeApiKey = process.env.OPENCODE_API_KEY;
+  process.env.OPENCODE_API_KEY = 'env-opencode-key';
+  globalThis.fetch = async (_url, init) => {
+    assert.equal(init.headers.authorization, 'Bearer env-opencode-key');
+    return makeResponse([
+      { data: { type: 'response.output_text.delta', delta: 'DeepSeek env auth accepted' } },
+      { data: { type: 'response.done', response: { output: [] } } },
+    ]);
+  };
+
+  try {
+    const result = await callApiStream(mockCtx(undefined), {
+      id: 'deepseek-v4-flash',
+      provider: 'opencode-go',
+      api: 'openai-completions',
+      baseUrl: 'https://opencode.ai/zen/go/v1',
+      reasoning: false,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search DeepSeek docs' }] }] });
+
+    assert.equal(result.providerKind, 'deepseek');
+    assert.equal(result.text, 'DeepSeek env auth accepted');
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousOpenCodeApiKey === undefined) delete process.env.OPENCODE_API_KEY;
+    else process.env.OPENCODE_API_KEY = previousOpenCodeApiKey;
+  }
+});
+
 test('Anthropic stream exposes server web search, result URLs, and citation details', async () => {
   const previousFetch = globalThis.fetch;
   globalThis.fetch = async (_url, init) => {


### PR DESCRIPTION
## Summary

Implements native DeepSeek web search (Responses API), closing [ttttmr/pi-web-search#17](https://github.com/ttttmr/pi-web-search/issues/17).

Pi's built-in DeepSeek models (`deepseek-v4-flash`, `deepseek-v4-pro`, …) report `api: "openai-completions"`, so `getProviderKind()` previously classified them as `unsupported` and `web_search` errored out.

## Recognition: by model id leaf, never by provider name

Pi hosts the same DeepSeek models under multiple providers — `deepseek`, `opencode-go`, `opencode`, `openrouter` — each with its own endpoint, credentials and billing. Matching on the provider name would silently miss all but the official provider.

`isDeepSeekResponsesModel()` therefore matches only the model id leaf (e.g. `deepseek-v4-flash`, `deepseek/deepseek-v4-flash` for router providers), following the same approach as [pi-deepseek-responses](https://github.com/yankewei/pi-deepseek-responses).

## Inherited endpoint, not a hardcoded URL

`callDeepSeekStream()` POSTs to `{model.baseUrl}/responses` — the provider-owned base URL is fully inherited, preserving per-provider endpoints (`https://api.deepseek.com`, `https://opencode.ai/zen/go/v1`, …), API key/OAuth resolution, headers and billing. No DeepSeek-specific URL is hardcoded.

## Implementation details

- Request body mirrors OpenAI's Responses format minus OpenAI-specific fields (no `include`, no Codex/Copilot transport). `tool_choice` left as `auto`.
- SSE events mirror OpenAI (`response.web_search_call.*`, `response.output_text.delta`). DeepSeek returns no structured `sources`/`results`; search activity is surfaced via `web_search_call` `action.queries` / `action.url`.
- Auth via `Authorization: Bearer`, reusing the existing resolver-based env API key fallback (e.g. `OPENCODE_API_KEY` for opencode-go, `DEEPSEEK_API_KEY` for deepseek).
- URL analysis (Gemini `url_context`) is intentionally not wired up — unsupported by the DeepSeek API.

## Tests added (3)

1. Routing to the inherited Responses endpoint (`https://opencode.ai/zen/go/v1/responses\)) with correct body and auth
2. Leaf-based recognition across hosting providers (deepseek / opencode / openrouter, incl. provider-qualified ids)
3. Env API key fallback for per-provider credentials

## Verification

- `npm test`: **36/36 passing** (33 existing + 3 new)
- `tsc --noEmit`: clean

## Open questions

- `tool_choice`: forced `{ type: "web_search" }` vs `auto`? Kept `auto`, consistent with the OpenAI path and pi-deepseek-responses.
- No real-API verification possible in this environment (no credentials); SSE event shapes follow the verified details in issue #17.