### PR TITLE
feat: support Azure OpenAI Responses web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Search the web using your currently selected model. Automatically picks the righ
 |---|---|
 | Google Gemini | Grounding with Google Search |
 | OpenAI | Responses API web search |
+| Azure OpenAI | Responses API web search (`azure-openai-responses`) |
 | OpenAI Codex | Codex Responses API web search |
 | Anthropic | Messages API web search |
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -34,7 +34,11 @@ const GOOGLE_PROVIDERS: Record<string, ProviderConfig> = {
 
 export function getProviderKind(model: Model<Api>): ProviderKind {
     if (GOOGLE_PROVIDERS[model.provider] || GOOGLE_PROVIDERS[model.api]) return "google";
-    if (model.api === "openai-responses" || model.api === "openai-codex-responses") return "openai";
+    if (
+        model.api === "openai-responses"
+        || model.api === "azure-openai-responses"
+        || model.api === "openai-codex-responses"
+    ) return "openai";
     if (model.api === "anthropic-messages") return "anthropic";
     return "unsupported";
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export function formatResult(text: string, details: any): AgentToolResult<any> {
 
 // --- Model Selection ---
 
-const SUPPORTED_PROVIDERS = ["google-generative-ai", "openai-responses", "openai-codex-responses", "anthropic-messages"];
+const SUPPORTED_PROVIDERS = ["google-generative-ai", "openai-responses", "azure-openai-responses", "openai-codex-responses", "anthropic-messages"];
 const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "agent", "web-search.json");
 
 type WebSearchModelConfig =

--- a/tests/api-parsing.test.mjs
+++ b/tests/api-parsing.test.mjs
@@ -168,6 +168,33 @@ test('non-Copilot Responses ignores proxy endpoint text in its API key', async (
   }
 });
 
+test('Azure OpenAI Responses appends /responses to the configured Azure v1 base URL', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    assert.equal(url, 'https://example-resource.cognitiveservices.azure.com/openai/v1/responses');
+    assert.equal(init.headers.authorization, 'Bearer entra-token');
+    const body = JSON.parse(init.body);
+    assert.equal(body.model, 'gpt-5.6-terra');
+    assert.deepEqual(body.tools, [{ type: 'web_search' }]);
+    return makeMinimalOpenAIResponse();
+  };
+
+  try {
+    const result = await callApiStream(mockCtx('entra-token'), {
+      id: 'gpt-5.6-terra',
+      provider: 'azure-openai',
+      api: 'azure-openai-responses',
+      baseUrl: 'https://example-resource.cognitiveservices.azure.com/openai/v1/',
+      reasoning: false,
+      headers: {},
+    }, { contents: [{ parts: [{ text: 'Search with Azure OpenAI' }] }] });
+
+    assert.equal(result.providerKind, 'openai');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
 test('OpenAI stream exposes native search calls, queries, URLs, and citations', async () => {
   const previousFetch = globalThis.fetch;
   globalThis.fetch = async (_url, init) => {
@@ -808,6 +835,26 @@ test('getModel does not fall back to another configured supported model', async 
   assert.match(result.content[0].text, /gpt-test/);
   assert.equal(result.details.error, 'unsupported_model');
   assert.deepEqual(result.details.availableSupportedModels, ['gpt-test (proxy-provider/openai-responses)']);
+});
+
+test('getModel accepts Azure OpenAI Responses models', async () => {
+  const model = {
+    id: 'gpt-5.6-terra',
+    provider: 'azure-openai',
+    api: 'azure-openai-responses',
+    baseUrl: 'https://example-resource.cognitiveservices.azure.com/openai/v1',
+    headers: {},
+  };
+  const ctx = {
+    model,
+    modelRegistry: {
+      getAvailable() {
+        return [model];
+      },
+    },
+  };
+
+  assert.equal(await getModel(ctx), model);
 });
 
 test('getModel accepts openai-codex Responses models', async () => {


### PR DESCRIPTION
## Summary

Add `azure-openai-responses` as a supported native web-search API.

This change classifies azure-openai-responses as OpenAI-compatible, allowing
it to use the existing Responses streaming, citation, and source parsing flow.

Azure configuration

Azure model configuration should use Azure's documented v1 base URL, for
example:

```text
https://<resource>.cognitiveservices.azure.com/openai/v1/
```

The existing Responses URL logic then requests:

```text
https://<resource>.cognitiveservices.azure.com/openai/v1/responses
```

No Azure-specific request transport is added. Pi's existing Azure auth
configuration provides the Entra bearer token.

Tests

- Add Azure Responses request test covering:
    - configured Azure v1 base URL
    - /responses endpoint construction
    - Entra bearer authentication
    - native web_search tool request
- Add Azure model-selection coverage.
- Verified against a real Azure Foundry azure-openai-responses model:
    - native web-search lifecycle events received
    - citations and source URLs returned
    - grounded result metadata returned

```env
PI_BIN=pi
PI_WEB_SEARCH_EXTENSION=./src/index.ts
PI_WEB_SEARCH_MODEL_OPENAI=azure-foundry-openai/gpt-5.6-terra
```

```bash
$ npm run test:real:web-search

> pi-web-search@1.3.1 test:real:web-search
> node tests/real-web-search.mjs


=== azure-foundry-openai/gpt-5.6-terra ===
{
  "exitCode": 0,
  "toolStarted": true,
  "toolEnded": true,
  "providerKind": "openai",
  "nativeSearchUsed": true,
  "nativeSearchEvents": [
    "response.web_search_call.in_progress",
    "response.web_search_call.searching",
    "response.web_search_call.completed"
  ],
  "searchQueries": [
    "site:platform.openai.com/docs Responses API web search tool citations OpenAI",
    "site:help.openai.com Responses API web search citations"
  ],
  "resultCount": 22,
  "grounded": true,
  "urls": [
    "https://platform.openai.com/docs/guides/tools-web-search",
    "https://platform.openai.com/docs/api-reference/responses-streaming/response/content_part/done?source=post_page-----e34daa331aa7---------------------------------------",
    "https://platform.openai.com/docs/api-reference/responses/create",
    "https://help.openai.com/en/articles/6639781",
    "https://platform.openai.com/docs/api-reference/responses-streaming/response/file_search_call/searching",
    "https://help.openai.com/en/articles/9237897-chatgpt-search",
    "https://platform.openai.com/docs/api-reference/responses-streaming/response/code_interpreter_call/in_progress",
    "https://help.openai.com/en/articles/10093903-chatgpt-search-for-enterprise-and-edu",
    "https://platform.openai.com/docs/api-reference/webhook-events/response/completed",
    "https://help.openai.com/en/articles/10500283-deep-research-in-chatgpt",
    "https://platform.openai.com/docs/api-reference/webhook-events/eval?.pptx=",
    "https://help.openai.com/",
    "https://platform.openai.com/docs/chatgpt-education",
    "https://help.openai.com/en/articles/8313428-chatgpt-and-fake-citations",
    "https://help.openai.com/en/collections/3742473-chatgpt",
    "https://help.openai.com/en/articles/10500283-leep-research-faq",
    "https://help.openai.com/en/articles/8550641-assistants-api-v2-faq",
    "https://help.openai.com/en/articles/11487775-apps-in-chatgpt",
    "https://help.openai.com/en/articles/20001203-offline-web-search-for-chatgpt-workspaces"
  ]
}
```

Reference

- Web search with the Responses API — Microsoft Foundry (https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/web-search)
- Use the Azure OpenAI Responses API — Microsoft Foundry (https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/responses)