### PR TITLE
fix: use provider default reasoning effort for web search

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -694,9 +694,8 @@ async function callOpenAIStream(
         stream: true,
         store: false,
     };
-    if (model.reasoning) {
-        requestBody.reasoning = { effort: "none" };
-    }
+    // Let the provider choose its supported reasoning default. Some reasoning
+    // models reject "none", and supported effort levels vary between models.
     if (isCodex) {
         requestBody.instructions = "Answer the user's request using web search when needed.";
         requestBody.text = { verbosity: "low" };

--- a/tests/api-parsing.test.mjs
+++ b/tests/api-parsing.test.mjs
@@ -61,6 +61,36 @@ function makeMinimalOpenAIResponse() {
   ]);
 }
 
+for (const [provider, api, baseUrl, apiKey] of [
+  ['openai', 'openai-responses', 'https://api.openai.com/v1', 'test-key'],
+  ['openai-codex', 'openai-codex-responses', 'https://chatgpt.com/backend-api', OPENAI_CODEX_TOKEN],
+  ['azure-openai', 'azure-openai-responses', 'https://example-resource.cognitiveservices.azure.com/openai/v1', 'test-key'],
+  ['github-copilot', 'openai-responses', 'https://api.individual.githubcopilot.com', 'test-key'],
+]) {
+  test(`${provider} web search leaves reasoning effort to the provider default`, async () => {
+    const previousFetch = globalThis.fetch;
+    let requestCount = 0;
+    globalThis.fetch = async (_url, init) => {
+      requestCount++;
+      const body = JSON.parse(init.body);
+      assert.equal(Object.hasOwn(body, 'reasoning'), false);
+      assert.deepEqual(body.tools, [{ type: 'web_search' }]);
+      return makeMinimalOpenAIResponse();
+    };
+
+    try {
+      for (const reasoning of [true, false]) {
+        await callApiStream(mockCtx(apiKey), {
+          id: 'gpt-6-astra', provider, api, baseUrl, reasoning, headers: {},
+        }, { contents: [{ parts: [{ text: 'Search OpenAI docs' }] }] });
+      }
+      assert.equal(requestCount, 2);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+}
+
 test('GitHub Copilot Responses uses the credential-specific base URL exposed by pi', async () => {
   const previousFetch = globalThis.fetch;
   globalThis.fetch = async (url, init) => {


### PR DESCRIPTION
## Problem
OpenAI-compatible web search requests unconditionally set `reasoning.effort: "none"` for reasoning models. This causes HTTP 400 errors on models that do not support disabling reasoning. Observed with `openai-codex/gpt-6-astra`, whose supported efforts start at `low`.

## Fix
Omit the reasoning override and let the provider use its supported model default rather than hard-coding another effort that may also be unsupported. This may use more reasoning than the previous override on models that accepted `none`.

Add request-body regression coverage for OpenAI, Codex, Azure OpenAI, and GitHub Copilot, for both reasoning and non-reasoning models.

## Validation
- `npm test`: 39 tests passed
- `npx tsc --noEmit`: passed
- `git diff --check`: passed